### PR TITLE
Added missing repoze.lru dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ warlock<2,>=1.0.1
 six>=1.9.0
 oslo.utils>=1.6.0 # Apache-2.0
 oslo.i18n>=1.5.0 # Apache-2.0
+repoze.lru


### PR DESCRIPTION
Without it, installs of latest glanceclient fail to run with ``ImportError`` 

```python
  File "lib/python2.6/site-packages/glanceclient/client.py", line 46, in Client
    module = utils.import_versioned_module(version, 'client')
  File "lib/python2.6/site-packages/glanceclient/common/utils.py", line 234, in import_versioned_module
    return importutils.import_module(module)
  File "lib/python2.6/site-packages/oslo_utils/importutils.py", line 57, in import_module
    __import__(import_str)
  File "lib/python2.6/site-packages/glanceclient/v2/client.py", line 19, in <module>
    from glanceclient.v2 import image_members
  File "lib/python2.6/site-packages/glanceclient/v2/image_members.py", line 16, in <module>
    import warlock
  File "lib/python2.6/site-packages/warlock/__init__.py", line 18, in <module>
    from warlock.core import model_factory
  File "lib/python2.6/site-packages/warlock/core.py", line 19, in <module>
    from . import model
  File "lib/python2.6/site-packages/warlock/model.py", line 21, in <module>
    import jsonschema
  File "lib/python2.6/site-packages/jsonschema/__init__.py", line 12, in <module>
    from jsonschema.exceptions import (
  File "lib/python2.6/site-packages/jsonschema/exceptions.py", line 6, in <module>
    from jsonschema import _utils
  File "lib/python2.6/site-packages/jsonschema/_utils.py", line 6, in <module>
    from jsonschema.compat import str_types, MutableMapping, urlsplit
  File "lib/python2.6/site-packages/jsonschema/compat.py", line 37, in <module>
    from repoze.lru import lru_cache
ImportError: No module named repoze.lru
```
